### PR TITLE
fix: ensure WebKit scrollbar pseudo-classes are cloned correctly

### DIFF
--- a/src/copy-pseudo-class.ts
+++ b/src/copy-pseudo-class.ts
@@ -4,21 +4,21 @@ import { getDiffStyle } from './get-diff-style'
 import { uuid } from './utils'
 
 const pseudoClasses = [
-  ':before',
-  ':after',
-  // ':placeholder', TODO
+  '::before',
+  '::after',
+  // '::placeholder', TODO
 ]
 
 const scrollbarPseudoClasses = [
-  ':-webkit-scrollbar',
-  ':-webkit-scrollbar-button',
-  // ':-webkit-scrollbar:horizontal', TODO
-  ':-webkit-scrollbar-thumb',
-  ':-webkit-scrollbar-track',
-  ':-webkit-scrollbar-track-piece',
-  // ':-webkit-scrollbar:vertical', TODO
-  ':-webkit-scrollbar-corner',
-  ':-webkit-resizer',
+  '::-webkit-scrollbar',
+  '::-webkit-scrollbar-button',
+  // '::-webkit-scrollbar:horizontal', TODO
+  '::-webkit-scrollbar-thumb',
+  '::-webkit-scrollbar-track',
+  '::-webkit-scrollbar-track-piece',
+  // '::-webkit-scrollbar:vertical', TODO
+  '::-webkit-scrollbar-corner',
+  '::-webkit-resizer',
 ]
 
 export function copyPseudoClass<T extends HTMLElement | SVGElement>(
@@ -86,7 +86,7 @@ export function copyPseudoClass<T extends HTMLElement | SVGElement>(
       allClasses = []
       svgStyles.set(cssText, allClasses)
     }
-    allClasses.push(`.${klasses[0]}:${pseudoClass}`)
+    allClasses.push(`.${klasses[0]}${pseudoClass}`)
   }
 
   pseudoClasses.forEach(copyBy)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Thanks for this awesome open-source project!

I found that WebKit scrollbar pseudo-classes are not being cloned correctly when I try to use this library in my production application.

#### Before

- [Live Demo](https://codesandbox.io/p/github/mass2527/modern-screenshot/before-fix)
- The scrollbar color(black) is not cloned.
- We can verify in the console that we need to pass "::-webkit-scrollbar" instead of ":-webkit-scrollbar" as the `pseudoElt` argument for the [getComputedStyle](https://developer.mozilla.org/ko/docs/Web/API/Window/getComputedStyle)￼ API.
- The ::after pseudo-element works correctly. (Add this to check whether the modified code affects it)

<img width="1919" height="974" alt="before" src="https://github.com/user-attachments/assets/4ba6d170-5cb8-45ac-bcdb-c3a55ddd42ae" />

#### After

- [Live Demo](https://codesandbox.io/p/github/mass2527/modern-screenshot/after-fix)
- The scroll bar color is correctly cloned.
- The ::after pseudo-element still works correctly.

<img width="1919" height="973" alt="스크린샷 2025-11-07 오후 6 49 17" src="https://github.com/user-attachments/assets/eb491ad5-0117-48ad-b179-9a278b2f2f9e" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
