### PR TITLE
fix(dev): fix svg rendering when directly targeting svg tag

### DIFF
--- a/src/converts/dom-to-foreign-object-svg.ts
+++ b/src/converts/dom-to-foreign-object-svg.ts
@@ -11,12 +11,21 @@ import {
   isSVGElementNode,
 } from '../utils'
 
+// Matches href="..." or xlink:href="..." that are NOT data URLs
+// Internal #refs also need processing since the referenced symbol may be in another SVG in the document
+const SVG_EXTERNAL_RESOURCE_REGEX = /\bx?link:?href\s*=\s*["'](?!data:)[^"']+["']/i
+
+function svgHasExternalResources(svg: SVGElement): boolean {
+  return SVG_EXTERNAL_RESOURCE_REGEX.test(svg.innerHTML)
+}
+
 export async function domToForeignObjectSvg<T extends Node>(node: T, options?: Options): Promise<SVGElement>
 export async function domToForeignObjectSvg<T extends Node>(context: Context<T>): Promise<SVGElement>
 export async function domToForeignObjectSvg(node: any, options?: any): Promise<SVGElement> {
   const context = await orCreateContext(node, options)
 
-  if (isElementNode(context.node) && isSVGElementNode(context.node))
+  // Skip processing for SVG elements that don't have external resources to embed
+  if (isElementNode(context.node) && isSVGElementNode(context.node) && !svgHasExternalResources(context.node))
     return context.node
 
   const {


### PR DESCRIPTION
### Description

This PR is an attempt to solve rendering failures when directly targeting an SVG tag. In particular, an svg may contain elements that may have to be serialised, but the library currently skips this step if the screenshot target is the svg element itself, caused by the following lines in `dom-to-foreign-object-svg.ts`:
```js
if (isElementNode(context.node) && isSVGElementNode(context.node))
    return context.node
```
This undesirable behaviour can be reproduced as following:
- go to [https://www.w3.org/WAI/tutorials/images/decorative/](https://www.w3.org/WAI/tutorials/images/decorative/)
- add modern-screenshot to the window environment: 
```js
const s = document.createElement("script")
s.src = "https://unpkg.com/modern-screenshot@4.6.7/dist/index.js"
document.head.appendChild(s)
```
- render any icons in the social section of the footer:
```js
await window.modernScreenshot.domToJpeg(document.querySelectorAll(".social a>svg")[0])
```

As a possible solution, by checking if the element contains an external reference using a regex, we can easily determine if the svg can actually be skipped or it is necessary to process it.

### Additional context

I'm not sure why the library skips svg elements when they are directly targeted so the proposed fix could not be compatible with other internal mechanism of the library. This behaviour causes, for example, the following two elements to render completly differntly (i.e., the second one is empty):
```html
<div style="display:inline-block"><svg focusable="false" aria-hidden="true" class="icon-linkedin "><use xlink:href="/WAI/assets/images/icons.svg#icon-linkedin"></use></svg></div>
```
and
```html
<svg focusable="false" aria-hidden="true" class="icon-linkedin "><use xlink:href="/WAI/assets/images/icons.svg#icon-linkedin"></use></svg>
```
The suggested fix is an efficient way to avoid this only for the necessary tags (note that the regex in the PR was llm generated and I'm unsure if it covers 100% of the possible instances for which we may want to process an svg). I have successfully tested it on the icons at https://www.w3.org/WAI/tutorials/images/decorative/.

Please also note that because the library is skipping SVG tags, I believe custom styling of the svg children is not being applied (such as color or opacity). This is fine for my use case and makes the library extremely fast which is what I most value, but it may be unintentional.
---

### What is the purpose of this pull request?

- [ X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
