### PR TITLE
fix: handle svg element IDs that start with digit

### DIFF
--- a/src/embed-svg-use.ts
+++ b/src/embed-svg-use.ts
@@ -1,6 +1,15 @@
 import type { Context } from './context'
 import { contextFetch } from './fetch'
 
+function findDescendantById(root: ParentNode, id: string, selector = '[id]'): Element | null {
+  for (const element of root.querySelectorAll(selector)) {
+    if (element.id === id)
+      return element
+  }
+
+  return null
+}
+
 export function embedSvgUse<T extends SVGUseElement>(
   cloned: T,
   context: Context,
@@ -19,9 +28,9 @@ export function embedSvgUse<T extends SVGUseElement>(
     const query = `#${id}`
     const definition = context.shadowRoots.reduce(
       (res, root) => {
-        return res ?? root.querySelector(`svg ${query}`)
+        return res ?? findDescendantById(root, id, 'svg [id]')
       },
-      ownerDocument?.querySelector(`svg ${query}`),
+      ownerDocument ? findDescendantById(ownerDocument, id, 'svg [id]') : null,
     )
 
     if (svgUrl) {
@@ -30,7 +39,7 @@ export function embedSvgUse<T extends SVGUseElement>(
       // No need to set xlink:href since this is ignored when href is set
     }
 
-    if (svgDefsElement?.querySelector(query))
+    if (svgDefsElement && findDescendantById(svgDefsElement, id))
       return [] // already exists in defs
 
     if (definition) { // found local embedded definition

--- a/test/nodejs.test.ts
+++ b/test/nodejs.test.ts
@@ -1,11 +1,13 @@
-import { Window } from 'happy-dom'
-import { describe, expect, it } from 'vitest'
-import { domToForeignObjectSvg } from '../src'
+import type { Context } from "../src/context";
+import { Window } from "happy-dom";
+import { describe, expect, it } from "vitest";
+import { domToForeignObjectSvg } from "../src";
+import { embedSvgUse } from "../src/embed-svg-use";
 
-describe('use happy-dom in nodejs', async () => {
-  it('dom to svg', async () => {
-    const window = new Window()
-    const document = window.document
+describe("use happy-dom in nodejs", async () => {
+  it("dom to svg", async () => {
+    const window = new Window();
+    const document = window.document;
     document.write(`
 <html>
   <body>
@@ -15,8 +17,45 @@ describe('use happy-dom in nodejs', async () => {
     </div>
   </body>
 </html>
-`)
-    const svg = await domToForeignObjectSvg(document.body as unknown as Node)
-    expect(svg.toString()).not.toBeNull()
-  })
-})
+`);
+    const svg = await domToForeignObjectSvg(document.body as unknown as Node);
+    expect(svg.toString()).not.toBeNull();
+  });
+
+  it("embed svg use with id starting with digit", () => {
+    const window = new Window();
+    const document = window.document;
+    document.write(`
+<html>
+  <body>
+    <svg style="display: none">
+      <symbol id="55180b_kitten" viewBox="0 0 24 24">
+        <path d="M5 12h14"></path>
+      </symbol>
+    </svg>
+    <svg>
+      <use href="#55180b_kitten"></use>
+    </svg>
+  </body>
+</html>
+`);
+
+    const useElement = document.querySelector(
+      "use",
+    ) as unknown as SVGUseElement;
+    const svgDefsElement = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "defs",
+    );
+    const context = {
+      ownerDocument: document,
+      svgDefsElement,
+      shadowRoots: [],
+    } as unknown as Context;
+
+    const tasks = embedSvgUse(useElement, context);
+
+    expect(tasks).toHaveLength(0);
+    expect(svgDefsElement.querySelector('[id="55180b_kitten"]')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
### Description

toPng fails for svg elements when their id starts with a digit. this handles that case.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
