### PR TITLE
fix: clone documentElement instead of body for same-origin iframes

### DIFF
--- a/src/clone-iframe.ts
+++ b/src/clone-iframe.ts
@@ -4,10 +4,10 @@ import { cloneNode } from './clone-node'
 export function cloneIframe<T extends HTMLIFrameElement>(
   iframe: T,
   context: Context,
-): HTMLIFrameElement | Promise<HTMLBodyElement> {
+): HTMLIFrameElement | Promise<HTMLElement> {
   try {
-    if (iframe?.contentDocument?.body) {
-      return cloneNode(iframe.contentDocument.body, context) as Promise<HTMLBodyElement>
+    if (iframe?.contentDocument?.documentElement) {
+      return cloneNode(iframe.contentDocument.documentElement, context) as Promise<HTMLElement>
     }
   }
   catch (error) {


### PR DESCRIPTION
### Description

My app embeds a same-origin iframe that has some styles defined in `head` and I'm noticing that these styles are not getting applied in the screenshot. I'm currently using the following workaround to patch the iframe before calling modern-screenshot.

```typescript
Object.defineProperty(iframe, "contentDocument", {
  configurable: true,
  get() {
    return new Proxy(contentDocument, {
      get(target, prop) {
        if (prop === "body") return target.documentElement;
        const value = Reflect.get(target, prop);
        return typeof value === "function" ? value.bind(target) : value;
      },
    });
  },
});
```

This workaround tricks modern-screenshot into reading the documentElement when it reads the body and it solves my immediate problem - the styles are getting applied now.

### Additional context

I'm a new contributor to this project so I might be lacking context on why this was written this way and what all the implications of making this change are. Let me know if you need anything from me to further investigate this issue or to get this PR merged.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
