### PR TITLE
fix: use detached document for @import rule processing

### DIFF
--- a/src/embed-web-font.ts
+++ b/src/embed-web-font.ts
@@ -39,11 +39,17 @@ export async function embedWebFont<T extends Element>(
       }
     })
 
+    // Collect rules from @import declarations into a detached stylesheet
+    // to avoid mutating the live document's stylesheets via insertRule().
+    const tempDoc = ownerDocument.implementation.createHTMLDocument('')
+    const tempStyleEl = tempDoc.createElement('style')
+    tempDoc.head.appendChild(tempStyleEl)
+    const tempStyleSheet = tempStyleEl.sheet!
+
     await Promise.all(
       styleSheets.flatMap((styleSheet) => {
-        return Array.from(styleSheet.cssRules).map(async (cssRule, index) => {
+        return Array.from(styleSheet.cssRules).map(async (cssRule) => {
           if (isCSSImportRule(cssRule)) {
-            let importIndex = index + 1
             const baseUrl = cssRule.href
             let cssText = ''
             try {
@@ -62,12 +68,7 @@ export async function embedWebFont<T extends Element>(
             )
             for (const rule of parseCss(replacedCssText)) {
               try {
-                styleSheet.insertRule(
-                  rule,
-                  rule.startsWith('@import')
-                    ? (importIndex += 1)
-                    : styleSheet.cssRules.length!,
-                )
+                tempStyleSheet.insertRule(rule, tempStyleSheet.cssRules.length)
               }
               catch (error) {
                 context.log.warn('Error inserting rule from remote css import', { rule, error })
@@ -77,6 +78,9 @@ export async function embedWebFont<T extends Element>(
         })
       }),
     )
+
+    if (tempStyleSheet.cssRules.length)
+      styleSheets.push(tempStyleSheet)
 
     const cssRules: CSSRule[] = []
     styleSheets.forEach((sheet) => {


### PR DESCRIPTION
## Description

`embedWebFont()` calls `insertRule()` directly on the live document's stylesheets when processing `@import` rules. The inserted rules are never cleaned up, permanently corrupting the host page's stylesheets.

This affects any page that uses `@import` in its CSS (e.g. via CSS frameworks, Rails `stylesheet_link_tag`, or any `<link>` tag that references a stylesheet containing `@import`). The corruption persists for the lifetime of the page.

### The fix

Create a detached document via `document.implementation.createHTMLDocument()` and insert the resolved `@import` rules into its stylesheet instead. The detached sheet is then appended to the `styleSheets` array so the existing `@font-face` iteration picks up the imported rules in a single pass — no changes needed downstream.

The detached document has no connection to the live DOM, no side effects, and is garbage collected when the function returns.

## Purpose

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [Commit Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Tested on a Rails application using `stylesheet_link_tag` with `@import` rules. Before the fix, the page's stylesheets were corrupted after calling `domToBlob()`. After the fix, stylesheets remain intact and screenshots render correctly including fonts from `@import`ed stylesheets.