### PR TITLE
fix: preserve selected option state when cloning select

### DIFF
--- a/src/copy-input-value.ts
+++ b/src/copy-input-value.ts
@@ -1,9 +1,24 @@
-import { isInputElement, isSelectElement, isTextareaElement } from './utils'
+import {
+  isInputElement,
+  isOptionElement,
+  isSelectElement,
+  isTextareaElement,
+} from './utils'
 
 export function copyInputValue<T extends HTMLElement | SVGElement>(
   node: T,
   cloned: T,
 ): void {
+  if (isOptionElement(node) && isOptionElement(cloned)) {
+    cloned.selected = node.selected
+
+    if (node.selected)
+      cloned.setAttribute('selected', '')
+    else cloned.removeAttribute('selected')
+
+    return
+  }
+
   if (isTextareaElement(node) || isInputElement(node) || isSelectElement(node)) {
     cloned.setAttribute('value', node.value)
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,7 @@ export const isVideoElement = (node: Element): node is HTMLVideoElement => node.
 export const isCanvasElement = (node: Element): node is HTMLCanvasElement => node.tagName === 'CANVAS'
 export const isTextareaElement = (node: Element): node is HTMLTextAreaElement => node.tagName === 'TEXTAREA'
 export const isInputElement = (node: Element): node is HTMLInputElement => node.tagName === 'INPUT'
+export const isOptionElement = (node: Element): node is HTMLOptionElement => node.tagName === 'OPTION'
 export const isStyleElement = (node: Element): node is HTMLStyleElement => node.tagName === 'STYLE'
 export const isScriptElement = (node: Element): node is HTMLScriptElement => node.tagName === 'SCRIPT'
 export const isSelectElement = (node: Element): node is HTMLSelectElement => node.tagName === 'SELECT'

--- a/test/nodejs.test.ts
+++ b/test/nodejs.test.ts
@@ -19,4 +19,29 @@ describe('use happy-dom in nodejs', async () => {
     const svg = await domToForeignObjectSvg(document.body as unknown as Node)
     expect(svg.toString()).not.toBeNull()
   })
+
+  it('preserves selected option state', async () => {
+    const window = new Window()
+    const document = window.document
+    document.write(`
+<html>
+  <body>
+    <select>
+      <option value="first" selected>First</option>
+      <option value="second">Second</option>
+      <option value="third">Third</option>
+    </select>
+  </body>
+</html>
+`)
+    const select = document.querySelector('select')!
+    select.value = 'second'
+
+    const svg = await domToForeignObjectSvg(document.body as unknown as Node)
+    const clonedOptions = svg.querySelectorAll('option')
+
+    expect(clonedOptions[0].hasAttribute('selected')).toBe(false)
+    expect(clonedOptions[1].hasAttribute('selected')).toBe(true)
+    expect(clonedOptions[2].hasAttribute('selected')).toBe(false)
+  })
 })


### PR DESCRIPTION
### Description

Fixes #159.

This PR preserves the live selected state of `<option>` elements when cloning form controls.

Previously, when generating an image from a `<select>`, the rendered output could fall back to the first/default option instead of the option currently selected by the user. Copying the `<select>` value alone is not enough for reliable rendering, because the visible selection is determined by the selected state of the child `<option>` elements.

This change syncs each cloned `<option>` with the original option’s current `selected` state, so generated PNG/SVG output reflects the actual selected value.

### Additional context

Added a regression test that starts with `First` selected in the markup, changes the live `<select>` value to `Second`, and verifies that only the cloned `Second` option is marked selected.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
