### PR TITLE
Preserve SVG fragments in CSS image URLs

### DIFF
--- a/src/css-url.ts
+++ b/src/css-url.ts
@@ -13,15 +13,16 @@ export async function replaceCssUrlToDataUrl(
 
   for (const [rawUrl, url] of parseCssUrls(cssText, baseUrl)) {
     try {
+      const [resourceUrl, fragment] = splitUrlFragment(url)
       const dataUrl = await contextFetch(
         context,
         {
-          url,
+          url: resourceUrl,
           requestType: isImage ? 'image' : 'text',
           responseType: 'dataUrl',
         },
       )
-      cssText = cssText.replace(toRE(rawUrl), `$1${dataUrl}$3`)
+      cssText = cssText.replace(toRE(rawUrl), `$1${dataUrl}${fragment}$3`)
     }
     catch (error) {
       context.log.warn('Failed to fetch css data url', rawUrl, error)
@@ -47,6 +48,14 @@ function parseCssUrls(cssText: string, baseUrl: string | null): [string, string]
   })
 
   return result.filter(([url]) => !isDataUrl(url))
+}
+
+function splitUrlFragment(url: string): [string, string] {
+  const index = url.indexOf('#')
+  if (index < 0)
+    return [url, '']
+
+  return [url.slice(0, index), url.slice(index)]
 }
 
 function toRE(url: string): RegExp {

--- a/test/nodejs.test.ts
+++ b/test/nodejs.test.ts
@@ -1,6 +1,7 @@
 import { Window } from 'happy-dom'
 import { describe, expect, it } from 'vitest'
 import { domToForeignObjectSvg } from '../src'
+import { replaceCssUrlToDataUrl } from '../src/css-url'
 
 describe('use happy-dom in nodejs', async () => {
   it('dom to svg', async () => {
@@ -18,5 +19,43 @@ describe('use happy-dom in nodejs', async () => {
 `)
     const svg = await domToForeignObjectSvg(document.body as unknown as Node)
     expect(svg.toString()).not.toBeNull()
+  })
+})
+
+describe('css url embedding', () => {
+  it('preserves SVG fragment identifiers when replacing image URLs', async () => {
+    const requestedUrls: string[] = []
+    const context = {
+      timeout: 0,
+      acceptOfImage: 'image/*',
+      requests: new Map(),
+      fetchFn: async (url: string) => {
+        requestedUrls.push(url)
+        return 'data:image/svg+xml;base64,PHN2Zy8+'
+      },
+      fetch: {
+        requestInit: {},
+        bypassingCache: false,
+        placeholderImage: '',
+      },
+      font: null,
+      workers: [],
+      fontFamilies: new Map(),
+      log: {
+        warn: () => {},
+      },
+    } as any
+
+    const css = await replaceCssUrlToDataUrl(
+      `url("https://example.com/image.svg#svgView(preserveAspectRatio(none))")`,
+      null,
+      context,
+      true,
+    )
+
+    expect(requestedUrls).toEqual(['https://example.com/image.svg'])
+    expect(css).toBe(
+      `url("data:image/svg+xml;base64,PHN2Zy8+#svgView(preserveAspectRatio(none))")`,
+    )
   })
 })


### PR DESCRIPTION
## Summary
- preserve SVG fragment identifiers such as `#svgView(...)` when CSS image URLs are embedded as data URLs
- fetch/cache the actual SVG resource without the fragment, then append the fragment back onto the generated data URL
- add a regression test for CSS `url("...svg#svgView(...)")` replacement

Fixes #142.

## Testing
- `corepack pnpm exec vitest run test/nodejs.test.ts --pool=forks --maxWorkers=1 --minWorkers=1 --no-file-parallelism`
- `corepack pnpm exec eslint src/css-url.ts test/nodejs.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

Note: the default Vitest worker-pool run crashed under local Node 24 before collecting tests, so I reran the focused test file with one worker and it passed.