### PR TITLE
fix: strip pseudo-element alt text so the content "/" separator does not leak

### DIFF
--- a/src/copy-pseudo-class.ts
+++ b/src/copy-pseudo-class.ts
@@ -43,6 +43,10 @@ export function copyPseudoClass<T extends HTMLElement | SVGElement>(
     addWordToFontFamilies?.(content)
 
     content = content
+      // Drop the pseudo-element's alt text (`content: "icon" / "alt"`), which is never rendered.
+      // Without this the `/` separator leaks into the clone — most visibly Font Awesome's
+      // `content: var(--fa) / ""`, which then renders the icon followed by a stray "/".
+      .replace(/ \/ .+$/, '')
       // TODO support css.counter
       .replace(/(')|(")|(counter\(.+\))/g, '')
 

--- a/test/fixtures/css.pseudo-content-alt-text.html
+++ b/test/fixtures/css.pseudo-content-alt-text.html
@@ -1,0 +1,19 @@
+<style>
+  #root {
+    font-size: 40px;
+    line-height: 1;
+  }
+
+  /* generated-content alt text: the `/ "star"` part is never rendered by the browser, but was
+     leaking into the clone as a stray "/" (same root cause as Font Awesome's `content: var(--fa) / ""`). */
+  #root::before {
+    content: "★" / "star";
+    color: gold;
+  }
+</style>
+
+<template>
+  <div id="root"></div>
+</template>
+
+<skip-expect />


### PR DESCRIPTION
Closes #168

## Problem

When a pseudo-element uses the CSS `content` **alt-text** syntax — `content: "icon" / "alt"` — the clone keeps a stray `/`. The most common trigger is **Font Awesome 6**, which sets `content: var(--fa) / ""` on every icon, so `domToPng` / `domToSvg` render each icon followed by a slash.

![before / after](https://raw.githubusercontent.com/ZushiH/modern-screenshot/pr-assets/repro-alt-text.png)

*Left: browser reference. Middle: current `modern-screenshot` (stray `/`). Right: with this fix.*

## Repro (no Font Awesome needed)

```html
<div id="el">hi</div>
<style>#el::before { content: "★" / "star"; }</style>
```

`getComputedStyle(el, '::before').content` → `"★" / "star"`. The screenshot renders the `::before` as `★ / star` instead of `★`.

## Root cause

`src/copy-pseudo-class.ts` de-quotes the computed `content` but never removes the `/ <alt>` part:

```ts
content = content
  // TODO support css.counter
  .replace(/(')|(")|(counter\(.+\))/g, '') // strips the quotes, leaves the " / " → "/"
```

The alt text after `/` is never rendered by the browser, but here it survives (quotes stripped, `/` separator left behind).

## Fix

Strip the alt text before de-quoting:

```ts
content = content
  // Drop the pseudo-element's alt text (`content: "icon" / "alt"`), which is never rendered.
  .replace(/ \/ .+$/, '')
  // TODO support css.counter
  .replace(/(')|(")|(counter\(.+\))/g, '')
```

The regex removes a trailing ` / …` alt segment only, so it doesn't touch `counter(...)` handling (which stays a TODO).

## Test

Added `test/fixtures/css.pseudo-content-alt-text.html` — a deterministic `content: "★" / "star"` case (no external font), modeled on the existing `css.font-icon.html` fixture. The browser suite's image comparison is currently caught-and-warned rather than asserted (the "puppeteer SVG not consistent across envs" TODO in `browser.test.ts`), so it's marked `<skip-expect />` and exercises the alt-text code path. If you'd prefer a hard regression assertion (e.g. asserting the cloned output no longer contains the `/`), I'm happy to wire it up however you like.