### PR TITLE
fix: treat loadMedia timeout of 0 as a zero-ms timeout instead of no timeout

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,7 +200,7 @@ export function loadMedia(media: any, options?: LoadMediaOptions): Promise<any> 
       removeEventListeners?.()
     }
 
-    if (timeout) {
+    if (timeout != null) {
       timer = setTimeout(onResolve, timeout)
     }
 

--- a/test/nodejs.test.ts
+++ b/test/nodejs.test.ts
@@ -1,6 +1,6 @@
 import { Window } from 'happy-dom'
 import { describe, expect, it } from 'vitest'
-import { domToForeignObjectSvg } from '../src'
+import { domToForeignObjectSvg, loadMedia } from '../src'
 
 describe('use happy-dom in nodejs', async () => {
   it('dom to svg', async () => {
@@ -18,5 +18,20 @@ describe('use happy-dom in nodejs', async () => {
 `)
     const svg = await domToForeignObjectSvg(document.body as unknown as Node)
     expect(svg.toString()).not.toBeNull()
+  })
+
+  it('loadMedia with timeout 0 resolves immediately instead of waiting forever', async () => {
+    const window = new Window()
+    const document = window.document
+    document.write('<html><body></body></html>')
+    // happy-dom never loads image resources, so without a timer this media
+    // would never fire `load`/`error` and the promise would hang
+    const img = document.createElement('img') as unknown as HTMLImageElement
+    img.src = 'http://localhost/never-loads.png'
+    const result = await Promise.race([
+      loadMedia(img, { timeout: 0 }).then(() => 'resolved'),
+      new Promise(resolve => setTimeout(() => resolve('hung'), 1000)),
+    ])
+    expect(result).toBe('resolved')
   })
 })


### PR DESCRIPTION
Fixes the `timeout: 0` handling in `loadMedia` (#170).

### Problem

`if (timeout)` is a truthy check, so `timeout: 0` disarms the safety timer entirely and `loadMedia` waits forever for media that never fires `load`/`error` — the opposite of what a caller passing `0` wants, and inconsistent with the `Options.timeout` docs ("millisecond, default: 30000").

### Change

`timeout != null` arms the timer for any numeric value including `0` (resolves on the next macrotask). `undefined` keeps the current wait-forever behavior for direct callers, and `createContext` still defaults to `30000`, so nothing changes for the normal `domTo*` paths.

### Test

Added a case to `test/nodejs.test.ts`: a happy-dom image never fires `load`/`error`, so before this change `loadMedia(img, { timeout: 0 })` hangs (test fails via a 1s guard race); after it, the promise resolves immediately.

We've been running with this behavior while capturing full-page screenshots of a dashboard-style web app in production.
